### PR TITLE
Triple-buffer and flip inputs on poll

### DIFF
--- a/SDLControllerWrapper/Controller.cs
+++ b/SDLControllerWrapper/Controller.cs
@@ -204,7 +204,7 @@
 
                 for (int i = 0; i < 3; i++)
                 {
-                    this._gyroAbsolutePositions[nextSample][i] += this._gyroAbsolutePositionsImmediate[i];
+                    this._gyroAbsolutePositions[nextSample][i] = this._gyroAbsolutePositions[this._currentSample][i] + this._gyroAbsolutePositionsImmediate[i];
                     this._gyroAbsolutePositionsImmediate[i] = 0;
                 }
             }


### PR DESCRIPTION
This is mainly intended to reduce the window where we might lose samples from the gyro.